### PR TITLE
Implement Database Resolver for RW and RO Databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@
 go.work
 go.work.sum
 
+.vscode
+
 # env file
 .env

--- a/db.go
+++ b/db.go
@@ -1,78 +1,221 @@
 package dbrouter
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"strings"
+	"sync/atomic"
+	"time"
 )
 
+// DB represents a logical database that manages multiple underlying physical databases.
+// It includes a single read-write (RW) database and multiple read-only (RO) databases.
+// The system automatically directs read and write operations to the appropriate database.
 type DB struct {
-	readWriteDB      *sql.DB   // master database
-	readOnlyDBs      []*sql.DB // replication Databases
-	totalConnections int       // total concurrent connections
-	readOnlyCount    uint64    // increasing monotonically on each query
+	readWriteDB      *sql.DB   // The primary (master) database for read-write operations.
+	readOnlyDBs      []*sql.DB // List of replication databases for read-only operations.
+	totalConnections int       // Total number of database connections (1 RW + n RO databases).
+	readOnlyCount    uint64    // Counter for load balancing read-only queries (used in round-robin).
 }
 
-func Open(driverName string, dataSourceName string) (*DB, error) {
+// Open initializes the connection to all physical databases (both RW and RO) concurrently.
+// `dataSourceNames` is a semicolon-separated list where the first entry is the RW database,
+// and subsequent entries are RO databases.
+func Open(driverName, dataSourceName string) (*DB, error) {
 	conns := strings.Split(dataSourceName, ";")
 	db := &DB{
-		readOnlyDBs:      make([]*sql.DB, len(conns)-1), // minus the master DB
-		totalConnections: len(conns),
+		readOnlyDBs:      make([]*sql.DB, len(conns)-1), // Allocate space for all RO databases.
+		totalConnections: len(conns),                    // Total connections = 1 RW + (n - 1) RO databases.
 	}
 
-	err := doConcurrent(db.totalConnections, func(i int) (err error) {
-		// open connection to master db
-		if i == 0 {
-			db.readWriteDB, err = sql.Open(driverName, conns[i])
-			return err
-		}
+	// Open all databases (RW and RO) concurrently.
+	err := db.openConnections(driverName, conns)
+	if err != nil {
+		return nil, err
+	}
 
-		// open connection to other replica db
-		var readOnlyDB *sql.DB
-		readOnlyDB, err = sql.Open(driverName, conns[i])
-		if err != nil {
-			return
-		}
-		db.readOnlyDBs[i-1] = readOnlyDB
-		return err
-	})
-
-	return db, err
-
+	return db, nil
 }
 
+// Close gracefully closes all database connections (RW and RO) concurrently.
 func (db *DB) Close() error {
-	return doConcurrent(db.totalConnections, func(i int) (err error) {
-		// close connection to master db
+	return doConcurrent(db.totalConnections, func(i int) error {
 		if i == 0 {
+			// Close the RW (master) database connection.
 			return db.readWriteDB.Close()
 		}
-
-		// close connection to replica db
+		// Close the RO (replica) database connection.
 		return db.readOnlyDBs[i-1].Close()
 	})
 }
 
+// Driver retrieves the driver for the RW database.
 func (db *DB) Driver() driver.Driver {
 	return db.readWriteDB.Driver()
 }
 
-// ----------
-// Todo:- add Begin
-// Todo:- add BeginTx
-// Todo:- add Exec
-// Todo:- add ExecContext
-// Todo:- add Ping
-// Todo:- add PingContext
-// Todo:- add Prepare
-// Todo:- add PrepareContext
-// Todo:- add Query
-// Todo:- add QueryContext
-// Todo:- add QueryRow
-// Todo:- add QueryRowContext
-// Todo:- add SetMaxIdleConns
-// Todo:- add SetMaxOpenConns
-// Todo:- add SetConnMaxLifetime
-// Todo:- add ReadOnly
-// Todo:- add ReadWrite
-// Todo:- add roundRobin
+// Begin initiates a transaction on the RW (master) database.
+func (db *DB) Begin() (*sql.Tx, error) {
+	return db.ReadWrite().Begin()
+}
+
+// BeginTx starts a transaction on the RW database with the given context and transaction options.
+// The transaction options (TxOptions) can be nil, and if the isolation level is unsupported by the driver, it returns an error.
+func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return db.ReadWrite().BeginTx(ctx, opts)
+}
+
+// Exec executes a query on the RW database without returning rows (e.g., INSERT, UPDATE).
+// Arguments are provided for query placeholders.
+func (db *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return db.ReadWrite().Exec(query, args...)
+}
+
+// ExecContext executes a query with context on the RW database without returning rows.
+func (db *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return db.ReadWrite().ExecContext(ctx, query, args...)
+}
+
+// Ping verifies that all database connections (RW and RO) are still alive, reconnecting if necessary.
+func (db *DB) Ping() error {
+	return doConcurrent(db.totalConnections, func(i int) error {
+		if i == 0 {
+			return db.readWriteDB.Ping()
+		}
+		return db.readOnlyDBs[i-1].Ping()
+	})
+}
+
+// PingContext performs the same operation as Ping but allows passing a context for cancellation or timeouts.
+func (db *DB) PingContext(ctx context.Context) error {
+	return doConcurrent(db.totalConnections, func(i int) error {
+		if i == 0 {
+			return db.readWriteDB.PingContext(ctx)
+		}
+		return db.readOnlyDBs[i-1].PingContext(ctx)
+	})
+}
+
+// Prepare creates a prepared statement for execution on the RW and RO databases.
+// It generates a statement for each database concurrently.
+func (db *DB) Prepare(query string) (Stmt, error) {
+	stmt := &stmt{db: db}
+	roStmts := make([]*sql.Stmt, len(db.readOnlyDBs))
+	err := doConcurrent(db.totalConnections, func(i int) (err error) {
+		if i == 0 {
+			stmt.rwstmt, err = db.readWriteDB.Prepare(query)
+			return err
+		}
+		// Prepare statement for each RO database.
+		roStmts[i-1], err = db.readOnlyDBs[i-1].Prepare(query)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	stmt.rostmts = roStmts
+	return stmt, nil
+}
+
+// PrepareContext creates a prepared statement using context for each underlying database (RW and RO).
+// The context is used during the preparation phase, not during execution.
+func (db *DB) PrepareContext(ctx context.Context, query string) (Stmt, error) {
+	stmt := &stmt{db: db}
+	roStmts := make([]*sql.Stmt, len(db.readOnlyDBs))
+	err := doConcurrent(db.totalConnections, func(i int) (err error) {
+		if i == 0 {
+			stmt.rwstmt, err = db.readWriteDB.PrepareContext(ctx, query)
+			return err
+		}
+		// Prepare context-based statement for RO databases.
+		roStmts[i-1], err = db.readOnlyDBs[i-1].PrepareContext(ctx, query)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	stmt.rostmts = roStmts
+	return stmt, nil
+}
+
+// Query executes a query on a RO database (selected using round-robin) and returns rows.
+// This is typically used for SELECT statements.
+func (db *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return db.ReadOnly().Query(query, args...)
+}
+
+// QueryContext executes a query with a context on a RO database and returns rows.
+func (db *DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return db.ReadOnly().QueryContext(ctx, query, args...)
+}
+
+// QueryRow executes a query on a RO database and returns at most one row.
+// This method always returns a non-nil result, with errors deferred until Scan is called.
+func (db *DB) QueryRow(query string, args ...interface{}) *sql.Row {
+	return db.ReadOnly().QueryRow(query, args...)
+}
+
+// QueryRowContext executes a query on a RO database and returns a single row with the provided context.
+func (db *DB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return db.ReadOnly().QueryRowContext(ctx, query, args...)
+}
+
+// SetMaxIdleConns sets the maximum number of idle connections allowed for each database (RW and RO).
+// If n <= 0, no idle connections will be retained.
+func (db *DB) SetMaxIdleConns(n int) {
+	db.readWriteDB.SetMaxIdleConns(n)
+	for _, roDB := range db.readOnlyDBs {
+		roDB.SetMaxIdleConns(n)
+	}
+}
+
+// SetMaxOpenConns sets the maximum number of open connections for each database.
+// If n <= 0, there is no limit on the number of open connections.
+func (db *DB) SetMaxOpenConns(n int) {
+	db.readWriteDB.SetMaxOpenConns(n)
+	for _, roDB := range db.readOnlyDBs {
+		roDB.SetMaxOpenConns(n)
+	}
+}
+
+// SetConnMaxLifetime sets the maximum amount of time a connection can remain open before being closed.
+func (db *DB) SetConnMaxLifetime(d time.Duration) {
+	db.readWriteDB.SetConnMaxLifetime(d)
+	for _, roDB := range db.readOnlyDBs {
+		roDB.SetConnMaxLifetime(d)
+	}
+}
+
+// ReadOnly returns a read-only database (selected via round-robin) to distribute read queries evenly.
+func (db *DB) ReadOnly() *sql.DB {
+	if db.totalConnections == 1 {
+		return db.readWriteDB // No read-only databases available.
+	}
+	return db.readOnlyDBs[db.roundRobin(len(db.readOnlyDBs))]
+}
+
+// ReadWrite returns the read-write (master) database for write operations.
+func (db *DB) ReadWrite() *sql.DB {
+	return db.readWriteDB
+}
+
+// roundRobin selects a read-only database based on a round-robin load balancing algorithm.
+func (db *DB) roundRobin(n int) int {
+	return int(atomic.AddUint64(&db.readOnlyCount, 1) % uint64(n))
+}
+
+// openConnections concurrently opens all database connections (RW and RO).
+func (db *DB) openConnections(driverName string, conns []string) error {
+	return doConcurrent(db.totalConnections, func(i int) error {
+		var err error
+		if i == 0 {
+			// Open the RW (master) database.
+			db.readWriteDB, err = sql.Open(driverName, conns[i])
+		} else {
+			// Open the RO (replica) databases.
+			db.readOnlyDBs[i-1], err = sql.Open(driverName, conns[i])
+		}
+		return err
+	})
+}

--- a/db.go
+++ b/db.go
@@ -1,0 +1,78 @@
+package dbrouter
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"strings"
+)
+
+type DB struct {
+	readWriteDB      *sql.DB   // master database
+	readOnlyDBs      []*sql.DB // replication Databases
+	totalConnections int       // total concurrent connections
+	readOnlyCount    uint64    // increasing monotonically on each query
+}
+
+func Open(driverName string, dataSourceName string) (*DB, error) {
+	conns := strings.Split(dataSourceName, ";")
+	db := &DB{
+		readOnlyDBs:      make([]*sql.DB, len(conns)-1), // minus the master DB
+		totalConnections: len(conns),
+	}
+
+	err := doConcurrent(db.totalConnections, func(i int) (err error) {
+		// open connection to master db
+		if i == 0 {
+			db.readWriteDB, err = sql.Open(driverName, conns[i])
+			return err
+		}
+
+		// open connection to other replica db
+		var readOnlyDB *sql.DB
+		readOnlyDB, err = sql.Open(driverName, conns[i])
+		if err != nil {
+			return
+		}
+		db.readOnlyDBs[i-1] = readOnlyDB
+		return err
+	})
+
+	return db, err
+
+}
+
+func (db *DB) Close() error {
+	return doConcurrent(db.totalConnections, func(i int) (err error) {
+		// close connection to master db
+		if i == 0 {
+			return db.readWriteDB.Close()
+		}
+
+		// close connection to replica db
+		return db.readOnlyDBs[i-1].Close()
+	})
+}
+
+func (db *DB) Driver() driver.Driver {
+	return db.readWriteDB.Driver()
+}
+
+// ----------
+// Todo:- add Begin
+// Todo:- add BeginTx
+// Todo:- add Exec
+// Todo:- add ExecContext
+// Todo:- add Ping
+// Todo:- add PingContext
+// Todo:- add Prepare
+// Todo:- add PrepareContext
+// Todo:- add Query
+// Todo:- add QueryContext
+// Todo:- add QueryRow
+// Todo:- add QueryRowContext
+// Todo:- add SetMaxIdleConns
+// Todo:- add SetMaxOpenConns
+// Todo:- add SetConnMaxLifetime
+// Todo:- add ReadOnly
+// Todo:- add ReadWrite
+// Todo:- add roundRobin

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,19 @@
+package dbrouter
+
+func doConcurrent(n int, fn func(i int) error) error {
+	errors := make(chan error, n)
+
+	var i int
+	for i = 0; i < n; i++ {
+		go func(i int) { errors <- fn(i) }(i)
+	}
+
+	var err, innerErr error
+	for i = 0; i < cap(errors); i++ {
+		if innerErr = <-errors; innerErr != nil {
+			err = innerErr
+		}
+	}
+
+	return err
+}

--- a/helper.go
+++ b/helper.go
@@ -1,19 +1,20 @@
 package dbrouter
 
+// doConcurrent runs a function concurrently n times and collects any errors.
+// It returns the last non-nil error, if any.
 func doConcurrent(n int, fn func(i int) error) error {
-	errors := make(chan error, n)
+	errors := make(chan error, n) // Channel to collect errors.
 
-	var i int
-	for i = 0; i < n; i++ {
-		go func(i int) { errors <- fn(i) }(i)
+	for i := 0; i < n; i++ {
+		go func(i int) { errors <- fn(i) }(i) // Launch goroutines to execute fn.
 	}
 
-	var err, innerErr error
-	for i = 0; i < cap(errors); i++ {
-		if innerErr = <-errors; innerErr != nil {
-			err = innerErr
+	var err error
+	for i := 0; i < n; i++ {
+		if e := <-errors; e != nil { // Collect errors from all goroutines.
+			err = e
 		}
 	}
 
-	return err
+	return err // Return the last non-nil error, or nil if no errors.
 }

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,18 @@
+package dbrouter
+
+import "database/sql"
+
+// WrapDBs initializes a DB instance with the provided database connections.
+// The first connection in the argument list is used as the primary (RW) database,
+// while the remaining connections are treated as read-only (RO) databases.
+// If no connections are provided, it will panic, as an RW connection is mandatory.
+func WrapDBs(dbs ...*sql.DB) *DB {
+	if len(dbs) == 0 {
+		panic("at least one RW connection is required")
+	}
+	return &DB{
+		readWriteDB:      dbs[0],   // First DB is the RW (primary) database.
+		readOnlyDBs:      dbs[1:],  // Subsequent DBs are RO (replica) databases.
+		totalConnections: len(dbs), // Total number of connections (RW + RO).
+	}
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,0 +1,71 @@
+package dbrouter
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestWrapDBs is a table-driven test that verifies the behavior of WrapDBs function.
+func TestWrapDBs(t *testing.T) {
+	// Create mock sql.DB instances
+	rwDB := &sql.DB{}  // Simulating RW DB (primary)
+	roDB1 := &sql.DB{} // Simulating RO DB 1
+	roDB2 := &sql.DB{} // Simulating RO DB 2
+
+	// Define test cases
+	tests := []struct {
+		name            string
+		input           []*sql.DB
+		expectPanic     bool
+		expectedRWDB    *sql.DB
+		expectedROCount int
+	}{
+		{
+			name:            "Valid RW and two RO connections",
+			input:           []*sql.DB{rwDB, roDB1, roDB2},
+			expectPanic:     false,
+			expectedRWDB:    rwDB,
+			expectedROCount: 2,
+		},
+		{
+			name:            "Valid RW with no RO connections",
+			input:           []*sql.DB{rwDB},
+			expectPanic:     false,
+			expectedRWDB:    rwDB,
+			expectedROCount: 0,
+		},
+		{
+			name:        "No connections provided (expect panic)",
+			input:       []*sql.DB{},
+			expectPanic: true,
+		},
+	}
+
+	// Iterate through test cases
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic but no panic occurred")
+					}
+				}()
+				// Call WrapDBs with inputs that are expected to cause a panic
+				WrapDBs(tc.input...)
+			} else {
+				// Call WrapDBs with valid input
+				db := WrapDBs(tc.input...)
+
+				// Assert RW DB is correct
+				if db.readWriteDB != tc.expectedRWDB {
+					t.Errorf("Expected RW DB to be %v, got %v", tc.expectedRWDB, db.readWriteDB)
+				}
+
+				// Assert the number of RO DBs is correct
+				if len(db.readOnlyDBs) != tc.expectedROCount {
+					t.Errorf("Expected %d RO DBs, got %d", tc.expectedROCount, len(db.readOnlyDBs))
+				}
+			}
+		})
+	}
+}

--- a/stmt.go
+++ b/stmt.go
@@ -1,0 +1,79 @@
+package dbrouter
+
+import (
+	"context"
+	"database/sql"
+)
+
+// Stmt represents an aggregate prepared statement.
+// It holds a prepared statement for both the RW and RO databases.
+type Stmt interface {
+	Close() error
+	Exec(...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, args ...interface{}) (sql.Result, error)
+	Query(...interface{}) (*sql.Rows, error)
+	QueryRow(...interface{}) *sql.Row
+}
+
+// stmt is the internal implementation of the Stmt interface.
+type stmt struct {
+	db      *DB         // Reference to the DB instance.
+	rwstmt  *sql.Stmt   // Prepared statement for the RW database.
+	rostmts []*sql.Stmt // Prepared statements for the RO databases.
+}
+
+// Close closes all prepared statements (RW and RO) concurrently.
+func (s *stmt) Close() error {
+	return doConcurrent(s.db.totalConnections, func(i int) error {
+		if i == 0 {
+			return s.rwstmt.Close() // Close RW statement.
+		}
+		return s.rostmts[i-1].Close() // Close RO statement.
+	})
+}
+
+// Exec executes a prepared statement on the RW database with the provided arguments.
+// It returns a Result summarizing the effect of the statement.
+func (s *stmt) Exec(args ...interface{}) (sql.Result, error) {
+	return s.RWStmt().Exec(args...)
+}
+
+// ExecContext executes a prepared statement with context on the RW database.
+func (s *stmt) ExecContext(ctx context.Context, args ...interface{}) (sql.Result, error) {
+	return s.RWStmt().ExecContext(ctx, args...)
+}
+
+// Query executes a prepared query on a RO database and returns the results as *sql.Rows.
+func (s *stmt) Query(args ...interface{}) (*sql.Rows, error) {
+	return s.ROStmt().Query(args...)
+}
+
+// QueryContext executes a prepared query with context on a RO database and returns the results as *sql.Rows.
+func (s *stmt) QueryContext(ctx context.Context, args ...interface{}) (*sql.Rows, error) {
+	return s.ROStmt().QueryContext(ctx, args...)
+}
+
+// QueryRow executes a query on a RO database and returns at most one row.
+// Errors are deferred until Scan is called on the returned *sql.Row.
+func (s *stmt) QueryRow(args ...interface{}) *sql.Row {
+	return s.ROStmt().QueryRow(args...)
+}
+
+// QueryRowContext executes a query with context on a RO database, returning a single row.
+// Errors are deferred until Scan is called on the returned *sql.Row.
+func (s *stmt) QueryRowContext(ctx context.Context, args ...interface{}) *sql.Row {
+	return s.ROStmt().QueryRowContext(ctx, args...)
+}
+
+// ROStmt returns the prepared statement for a RO database, selected using round-robin.
+func (s *stmt) ROStmt() *sql.Stmt {
+	if len(s.rostmts) == 0 {
+		return s.rwstmt // If no RO statements exist, fall back to the RW statement.
+	}
+	return s.rostmts[s.db.roundRobin(len(s.rostmts))]
+}
+
+// RWStmt returns the prepared statement for the RW (master) database.
+func (s *stmt) RWStmt() *sql.Stmt {
+	return s.rwstmt
+}


### PR DESCRIPTION
### Description:
This PR introduces a robust database resolver that allows for the seamless handling of multiple physical databases, including a primary read-write (RW) database and multiple read-only (RO) databases. 
Key functionalities include:

`WrapDBs`: A function to initialize the resolver by wrapping the RW and RO database connections. The first connection is treated as the RW database, and subsequent connections are considered RO databases.

**Automatic Read/Write Routing**: The resolver automatically directs write operations (INSERT, UPDATE, DELETE) to the RW database and read operations (SELECT) to the RO databases using a round-robin load balancing approach.

**Concurrency Handling**: The resolver efficiently manages concurrent operations across multiple databases using the `doConcurrent` helper function, which runs database operations in parallel and aggregates errors if they occur.

**Transaction Support**: Full transaction support is implemented, including methods for beginning standard transactions and transactions with context (`Begin` and `BeginTx`).

**Connection Pooling**: Added support for configuring connection pooling across both RW and RO databases, with methods to set max idle connections, max open connections, and connection lifetimes (`SetMaxIdleConns`, `SetMaxOpenConns`, `SetConnMaxLifetime`).

**Prepared Statements**: The resolver supports prepared statements across both the RW and RO databases, allowing efficient query execution and reuse.

### Why this is needed:
This implementation provides a scalable and efficient way to manage database queries for systems utilizing database replication. It ensures that read operations are distributed across RO databases, improving performance and load distribution, while write operations are consistently directed to the RW database.